### PR TITLE
fix: internal links not working.

### DIFF
--- a/sanity/queries/navigation.ts
+++ b/sanity/queries/navigation.ts
@@ -1,9 +1,12 @@
 import { groq } from "next-sanity";
+import { linkQuery } from "./shared/link";
 
 export const NAVIGATION_QUERY = groq`
   *[_type == "navigation"]{
     _type,
     _key,
-    links
+    links[]{
+      ${linkQuery}
+    }
   }
 `;


### PR DESCRIPTION
Navigation with the imported data set works as expected.

When I create a new navigation item, with "Internal Link" pointing to an internal Page, e.g. "Lighthouse Scores", the navigation item is surfaced in the site navigation, but not appropriately linking to the page.